### PR TITLE
Remove Twitter Link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,6 @@ url: "https://pacechallenge.org" # the base hostname & protocol for your site, e
 
 permalink: pretty
 
-twitter_username: PACE_challenge
 github_username: PACE-challenge
 
 logo: /assets/img/turtle.svg


### PR DESCRIPTION
Given developments on Twitter (recently X), many German universities [decided to withdraw](https://aktuelles.uni-frankfurt.de/english/goethe-university-frankfurt-and-numerous-other-german-universities-withdraw-from-x/) from this platform. In my opinion, this is an important statement and we should stop normalizing Twitter links on every website.

From what I can gleam the PACE's Twitter account was not recently used anyhow, so I do not expect a negative impact for the PACE community.

